### PR TITLE
Do Not Mutate Strings

### DIFF
--- a/src/query-string-utils/QueryStringBuilder.test.ts
+++ b/src/query-string-utils/QueryStringBuilder.test.ts
@@ -33,7 +33,7 @@ test('forms a valid query string from config object', () => {
   expect(queryString).toBe(expected);
 });
 
-test('encodes special chars', () => {
+test('does not encode special chars', () => {
 
   configs = [
     {
@@ -42,7 +42,7 @@ test('encodes special chars', () => {
     }
   ];
 
-  expected = '?s%20p%20a%20c%20e%20s=s%20%20%20p%20%20%20a%20%20%20c%20%20%20e%20%20%20s'
+  expected = '? s p a c e s     = s   p   a   c   e   s  '
   queryString = new QueryStringBuilder().withConfig(configs).build().getString();
   expect(queryString).toBe(expected);
 });

--- a/src/query-string-utils/QueryStringBuilder.ts
+++ b/src/query-string-utils/QueryStringBuilder.ts
@@ -84,7 +84,7 @@ class QueryStringBuilder {
         defaultValue = config.defaultValue,
 				urlOverride = false,
 				param = {
-					key: encodeURI(paramName.trim()),
+					key: paramName.trim(),
           value: '',
         };
 
@@ -107,7 +107,7 @@ class QueryStringBuilder {
       }
       else {
         primaryValue = typeof primaryValue !== 'undefined' ? String(primaryValue) : '';
-        param.value = encodeURI(primaryValue.trim());
+        param.value = primaryValue.trim();
         primaryValue = true;
       }
 		}
@@ -118,7 +118,7 @@ class QueryStringBuilder {
       }
       else {
         defaultValue = typeof defaultValue !== 'undefined' ? String(defaultValue) : '';
-        param.value = encodeURI(defaultValue.trim());
+        param.value = defaultValue.trim();
         defaultValue = true;
       }
 		}

--- a/src/query-string-utils/QueryStringBuilder.ts
+++ b/src/query-string-utils/QueryStringBuilder.ts
@@ -84,7 +84,7 @@ class QueryStringBuilder {
         defaultValue = config.defaultValue,
 				urlOverride = false,
 				param = {
-					key: paramName.trim(),
+					key: paramName,
           value: '',
         };
 
@@ -107,7 +107,7 @@ class QueryStringBuilder {
       }
       else {
         primaryValue = typeof primaryValue !== 'undefined' ? String(primaryValue) : '';
-        param.value = primaryValue.trim();
+        param.value = primaryValue;
         primaryValue = true;
       }
 		}
@@ -118,7 +118,7 @@ class QueryStringBuilder {
       }
       else {
         defaultValue = typeof defaultValue !== 'undefined' ? String(defaultValue) : '';
-        param.value = defaultValue.trim();
+        param.value = defaultValue;
         defaultValue = true;
       }
 		}


### PR DESCRIPTION
Remove encoding from key/value pairs. I want to leave this up to the user so the user has more control. Additionally, remove calls to the .trim() method on key/value pairs. I do not want to mutate values given to the builder. Again, I believe this be beneficial as it will give more control to the user. 