### PR TITLE
Feature/add `.all()` and `.get()` methods to the QueryStringParser

### DIFF
--- a/src/query-string-utils/QueryStringParser.test.ts
+++ b/src/query-string-utils/QueryStringParser.test.ts
@@ -82,3 +82,31 @@ test('a query string with a value of "&"', () => {
   expect(parsedQuery).toEqual(expected);
 
 });
+
+test('.all() method returns all key/value pairs', () => {
+
+  let queryString,
+      parsedQuery;
+
+  // test a normal query string ...
+  queryString = "?test1&test2&test3&test4";
+  parsedQuery = new QueryStringParser(queryString).all();
+  expect(parsedQuery.length).toEqual(4);
+
+});
+
+test('.get() method returns one key/value pair', () => {
+
+  let queryString,
+      parsedQuery;
+
+  // test a normal query string ...
+  queryString = "?test1&test2&test3&test4=test";
+  parsedQuery = new QueryStringParser(queryString).get('test4');
+  expect(parsedQuery.key).toEqual('test4');
+  expect(parsedQuery.value).toEqual('test');
+
+  parsedQuery = new QueryStringParser(queryString).get('not-there');
+  expect(parsedQuery).toEqual(null);
+
+});

--- a/src/query-string-utils/QueryStringParser.ts
+++ b/src/query-string-utils/QueryStringParser.ts
@@ -1,6 +1,29 @@
 import { QueryStringObject  } from './contracts';
+import { QueryStringBuilder } from './QueryStringBuilder';
 
 class QueryStringParser {
+
+  private queryString:string
+  private queryObjects:Array<QueryStringObject>
+
+  public constructor(queryString:string) {
+    this.queryString = queryString;
+    this.queryObjects = QueryStringParser.getQueryObject(this.queryString);
+  }
+
+  public all() {
+    return this.queryObjects;
+  }
+
+  public get(key:string) {
+    let result = this.queryObjects.filter(queryObject => {
+      return queryObject.key === key;
+    });
+    if(result.length > 0) {
+      return result[0];
+    }
+    return null;
+  }
 
   public static getQueryObject(queryString:string): Array<QueryStringObject> {
 

--- a/src/query-string-utils/QueryStringParser.ts
+++ b/src/query-string-utils/QueryStringParser.ts
@@ -20,7 +20,7 @@ class QueryStringParser {
       return queryObject.key === key;
     });
     if(result.length > 0) {
-      return result[0];
+      return result.pop();
     }
     return null;
   }


### PR DESCRIPTION
Added `.all()` and `.get()` methods to the QueryStringParser. 
`.all()` returns an array of all key/value paris.
`.get()` returns the last key/value pair with a matching key