### PR TITLE
QSP - Update .get() method.

### DIFF
--- a/src/query-string-utils/QueryStringParser.test.ts
+++ b/src/query-string-utils/QueryStringParser.test.ts
@@ -95,7 +95,7 @@ test('.all() method returns all key/value pairs', () => {
 
 });
 
-test('.get() method returns one key/value pair', () => {
+test('.get() method returns one value', () => {
 
   let queryString,
       parsedQuery;
@@ -103,8 +103,7 @@ test('.get() method returns one key/value pair', () => {
   // test a normal query string ...
   queryString = "?test1&test2&test3&test4=test";
   parsedQuery = new QueryStringParser(queryString).get('test4');
-  expect(parsedQuery.key).toEqual('test4');
-  expect(parsedQuery.value).toEqual('test');
+  expect(parsedQuery).toEqual('test');
 
   parsedQuery = new QueryStringParser(queryString).get('not-there');
   expect(parsedQuery).toEqual(null);

--- a/src/query-string-utils/QueryStringParser.ts
+++ b/src/query-string-utils/QueryStringParser.ts
@@ -20,7 +20,10 @@ class QueryStringParser {
       return queryObject.key === key;
     });
     if(result.length > 0) {
-      return result.pop();
+      let lastItem = result.pop();
+      if(lastItem) {
+        return lastItem.value;
+      }
     }
     return null;
   }


### PR DESCRIPTION
.get() method should return a string or null instead of an object or null.